### PR TITLE
Moved the exception given in xml output to the trace output

### DIFF
--- a/src/main/java/org/wearefrank/xsltdebugger/XSLTReporterSetup.java
+++ b/src/main/java/org/wearefrank/xsltdebugger/XSLTReporterSetup.java
@@ -70,7 +70,7 @@ public class XSLTReporterSetup {
             transformer.getTraceManager().addTraceListener(traceListener);
             transformer.transform(xmlSource, result);
         } catch (Exception e) {
-            writer.append(e.toString());
+            this.traceListener.getSelectedTrace().addTraceContext(String.format("\n%s", e));
         } finally {
             writer.close();
         }
@@ -93,7 +93,7 @@ public class XSLTReporterSetup {
             transformer.transform(xmlContext.getSourceObject(), result);
 
         } catch (Exception e) {
-            writer.append(e.toString());
+            this.traceListener.getSelectedTrace().addTraceContext(String.format("\n%s", e));
         } finally {
             writer.close();
         }

--- a/src/main/java/org/wearefrank/xsltdebugger/trace/LadybugTraceListener.java
+++ b/src/main/java/org/wearefrank/xsltdebugger/trace/LadybugTraceListener.java
@@ -6,4 +6,5 @@ public interface LadybugTraceListener {
     /**Root trace of the tree that that holds all the traces.
      * @return returns the root trace*/
     Trace getRootTrace();
+    Trace getSelectedTrace();
 }

--- a/src/main/java/org/wearefrank/xsltdebugger/trace/SaxonTraceListener.java
+++ b/src/main/java/org/wearefrank/xsltdebugger/trace/SaxonTraceListener.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 public class SaxonTraceListener extends StandardDiagnostics implements TraceListener, LadybugTraceListener {
     @Getter
     private final Trace rootTrace = new Trace();
+    @Getter
     private Trace selectedTrace;
     //needed because the order of the methods to end a trace is reversed for some reason by saxon
     private boolean end;

--- a/src/main/java/org/wearefrank/xsltdebugger/trace/XalanTraceListener.java
+++ b/src/main/java/org/wearefrank/xsltdebugger/trace/XalanTraceListener.java
@@ -32,6 +32,7 @@ public class XalanTraceListener implements TraceListenerEx2, LadybugTraceListene
 
     @Getter
     private final Trace rootTrace = new Trace();
+    @Getter
     private Trace selectedTrace;
     /**
      * This needs to be set to true if the listener is to print an event whenever a template is invoked.


### PR DESCRIPTION
Solves issue #29 
Exception was shown in output xml. Instead it should be shown in the trace output for debugging.
Added a getter for selectedTrace so that the exception can be added to the node that was currently being done.